### PR TITLE
Set T-deck external notifications to false by default

### DIFF
--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -358,7 +358,7 @@ void NodeDB::installDefaultModuleConfig()
 #endif
 #ifdef HAS_I2S
     // Don't worry about the other settings for T-Watch, we'll also use the DRV2056 behavior for notifications
-    moduleConfig.external_notification.enabled = true;
+    moduleConfig.external_notification.enabled = false;
     moduleConfig.external_notification.use_i2s_as_buzzer = true;
     moduleConfig.external_notification.alert_message_buzzer = true;
     moduleConfig.external_notification.nag_timeout = 60;

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -347,11 +347,11 @@ ExternalNotificationModule::ExternalNotificationModule()
     // moduleConfig.external_notification.nag_timeout = 300;
 
     // T-Watch / T-Deck i2s audio as buzzer:
-    moduleConfig.external_notification.enabled = false;
+    // moduleConfig.external_notification.enabled = true;
     // moduleConfig.external_notification.nag_timeout = 300;
     // moduleConfig.external_notification.output_ms = 1000;
-    moduleConfig.external_notification.use_i2s_as_buzzer = false;
-    moduleConfig.external_notification.alert_message_buzzer = false;
+    // moduleConfig.external_notification.use_i2s_as_buzzer = true;
+    // moduleConfig.external_notification.alert_message_buzzer = true;
 
     if (moduleConfig.external_notification.enabled) {
         if (nodeDB->loadProto(rtttlConfigFile, meshtastic_RTTTLConfig_size, sizeof(meshtastic_RTTTLConfig),

--- a/src/modules/ExternalNotificationModule.cpp
+++ b/src/modules/ExternalNotificationModule.cpp
@@ -347,11 +347,11 @@ ExternalNotificationModule::ExternalNotificationModule()
     // moduleConfig.external_notification.nag_timeout = 300;
 
     // T-Watch / T-Deck i2s audio as buzzer:
-    // moduleConfig.external_notification.enabled = true;
+    moduleConfig.external_notification.enabled = false;
     // moduleConfig.external_notification.nag_timeout = 300;
     // moduleConfig.external_notification.output_ms = 1000;
-    // moduleConfig.external_notification.use_i2s_as_buzzer = true;
-    // moduleConfig.external_notification.alert_message_buzzer = true;
+    moduleConfig.external_notification.use_i2s_as_buzzer = false;
+    moduleConfig.external_notification.alert_message_buzzer = false;
 
     if (moduleConfig.external_notification.enabled) {
         if (nodeDB->loadProto(rtttlConfigFile, meshtastic_RTTTLConfig_size, sizeof(meshtastic_RTTTLConfig),


### PR DESCRIPTION
(Third time's the charm, right?)

To protect the sanity of DefCon attendees, this change sets the notification on the T-deck to be disabled by default as requested in https://github.com/meshtastic/firmware/issues/4359